### PR TITLE
replaceAll() instead of replace()

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -120,11 +120,11 @@ function formatBody(raw) {
 */
 function formatTime(time) {
 	if (time.indexOf("am") !== -1) {
-		time = time.replace("am","a.m.");
+		time = time.replaceAll("am","a.m.");
 	}
 
 	if (time.indexOf("pm") !== -1) {
-		time = time.replace("pm","p.m.");
+		time = time.replaceAll("pm","p.m.");
 	}
 
 	if (time.indexOf("EDT") === -1 && time.indexOf("ET") === -1 && time.indexOf("EST") === -1) {


### PR DESCRIPTION
Fixed bug where only first instance of 'am' or 'pm' in time was correctly formatted as 'a.m.' and 'p.m.'