### PR TITLE
#14 Adobe Acrobat support

### DIFF
--- a/alerts.html
+++ b/alerts.html
@@ -49,7 +49,7 @@
 </div>
 
 <footer class="page-footer font-small">
-	<div class="footer-copyright text-center py-3">Created by <a href="mailto:blakecoo@buffalo.edu" id="email">Blake Cooper</a>. Updated 8/3/2021.
+	<div class="footer-copyright text-center py-3">Created by <a href="mailto:blakecoo@buffalo.edu" id="email">Blake Cooper</a>. Updated 8/30/2021.
   	</div>
 </footer>
 

--- a/consts.js
+++ b/consts.js
@@ -101,5 +101,13 @@ const TIME = 3;
 const WHO = 4;
 const BODY = 5;
 
+/* For readability purposes, a macro representing the first index position of a string */
+const START_OF_STRING = 0;
+
 /* The highest index the cursor can reach (designed to prevent infinite loops) */
 const CURSOR_LIMIT = 10000;
+
+/* Adobe Acrobat uses a completely different format for copied text from PDFs. This helps
+the script identify whether the notice was opened in Acrobat and does certain tasks
+differently, depending. */
+const ACROBAT_MARKER = "University Facilities";


### PR DESCRIPTION
Because Adobe Acrobat formats text copied from a PDF, some of the markers used in the script (particularly those that determine how the body of the alert is formatted) were not working correctly. The new script:

1. Checks for standard markers of an Acrobat copy-and-paste (specifically, the footer is at the top for some reason?)
2. Skips existing formatting method and instead runs a method that strips the several erroneous line breaks that Acrobat inserts from the body

More work likely needs to be done to find and remove new bugs resulting from using Acrobat to open the PDF.